### PR TITLE
M-26: Like/unlike backend

### DIFF
--- a/backend/Application/Commands/LikeUserCommand.cs
+++ b/backend/Application/Commands/LikeUserCommand.cs
@@ -1,0 +1,27 @@
+using Domain.Entities;
+using Domain.Exceptions;
+using Domain.Repositories;
+using MediatR;
+
+namespace Application.Commands;
+
+public record LikeUserCommand(int LikerId, int LikedId) : IRequest<bool>;
+
+public class LikeUserCommandHandler(IUserRepository userRepository) : IRequestHandler<LikeUserCommand, bool>
+{
+	public async Task<bool> Handle(LikeUserCommand request, CancellationToken cancellationToken)
+	{
+		if (request.LikerId == request.LikedId)
+		{
+			throw new SelfLikeException();
+		}
+
+		if (await userRepository.GetById(request.LikedId) == null)
+		{
+			throw new UserNotFoundException(request.LikedId.ToString());
+		}
+
+		await userRepository.LikeUser(request.LikerId, request.LikedId);
+		return await userRepository.HasUserLiked(request.LikedId, request.LikerId);
+	}
+}

--- a/backend/Application/Commands/UnlikeUserCommand.cs
+++ b/backend/Application/Commands/UnlikeUserCommand.cs
@@ -1,0 +1,23 @@
+using Domain.Exceptions;
+using Domain.Repositories;
+using MediatR;
+
+namespace Application.Commands;
+
+public record UnlikeUserCommand(int LikerId, int LikedId) : IRequest;
+
+public class UnlikeUserCommandHandler(IUserRepository userRepository) : IRequestHandler<UnlikeUserCommand>
+{
+	public async Task Handle(UnlikeUserCommand request, CancellationToken cancellationToken)
+	{
+		if (request.LikerId == request.LikedId)
+		{
+			throw new SelfLikeException();
+		}
+		if (await userRepository.GetById(request.LikedId) == null)
+		{
+			throw new UserNotFoundException(request.LikedId.ToString());
+		}
+		await userRepository.UnlikeUser(request.LikerId, request.LikedId);
+	}
+}

--- a/backend/Domain/Exceptions/SelfLikeException.cs
+++ b/backend/Domain/Exceptions/SelfLikeException.cs
@@ -1,0 +1,3 @@
+namespace Domain.Exceptions;
+
+public class SelfLikeException() : DomainException("You cannot like your own profile.");

--- a/backend/Domain/Repositories/IUserRepository.cs
+++ b/backend/Domain/Repositories/IUserRepository.cs
@@ -21,4 +21,7 @@ public interface IUserRepository
     Task SetProfilePicture(int userId, int pictureId);
     Task<bool> IsProfileComplete(int userId);
     Task ClearRefreshToken(int userId);
+    Task LikeUser(int likerId, int likedId);
+    Task UnlikeUser(int likerId, int likedId);
+    Task<bool> HasUserLiked(int likerId, int likedId);
 }

--- a/backend/Infrastructure/Repositories/UserRepository.cs
+++ b/backend/Infrastructure/Repositories/UserRepository.cs
@@ -414,4 +414,34 @@ public async Task<UserProfile?> GetUserProfile(int id)
         command.Parameters.AddWithValue("@userId", userId);
         await command.ExecuteNonQueryAsync();
     }
+
+    public async Task LikeUser(int likerId, int likedId)
+    {
+        await using NpgsqlConnection conn = factory.CreateConnection();
+        await conn.OpenAsync();
+        await using NpgsqlCommand likeUser = new NpgsqlCommand("INSERT INTO user_likes (liker_id, liked_id) VALUES (@likerId, @likedId) ON CONFLICT (liker_id, liked_id) DO NOTHING;", conn);
+        likeUser.Parameters.AddWithValue("@likerId", likerId);
+        likeUser.Parameters.AddWithValue("@likedId", likedId);
+        await likeUser.ExecuteNonQueryAsync();
+    }
+
+    public async Task UnlikeUser(int likerId, int likedId)
+    {
+        await using NpgsqlConnection conn = factory.CreateConnection();
+        await conn.OpenAsync();
+        await using NpgsqlCommand unlikeUser = new NpgsqlCommand("DELETE FROM user_likes WHERE liker_id = @likerId AND liked_id = @likedId", conn);
+        unlikeUser.Parameters.AddWithValue("@likerId", likerId);
+        unlikeUser.Parameters.AddWithValue("@likedId", likedId);
+        await unlikeUser.ExecuteNonQueryAsync();
+    }
+
+    public async Task<bool> HasUserLiked(int likerId, int likedId)
+    {
+        await using NpgsqlConnection conn = factory.CreateConnection();
+        await conn.OpenAsync();
+        await using NpgsqlCommand query = new NpgsqlCommand("SELECT EXISTS(SELECT 1 FROM user_likes WHERE liker_id = @likerId AND liked_id = @likedId);", conn);
+        query.Parameters.AddWithValue("@likerId", likerId);
+        query.Parameters.AddWithValue("@likedId", likedId);
+        return await query.ExecuteScalarAsync() is true;
+    }
 }

--- a/backend/Matcha.Tests/LikeUserCommandHandlerTests.cs
+++ b/backend/Matcha.Tests/LikeUserCommandHandlerTests.cs
@@ -1,0 +1,92 @@
+using Application.Commands;
+using Domain.Entities;
+using Domain.Exceptions;
+using Domain.Repositories;
+using NSubstitute;
+
+namespace Matcha.Tests;
+
+public class LikeUserCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_SelfLike_Throws()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new LikeUserCommandHandler(repository);
+		var command = new LikeUserCommand(1, 1);
+
+		await Assert.ThrowsAsync<SelfLikeException>(() =>
+			handler.Handle(command, CancellationToken.None));
+
+		await repository.DidNotReceiveWithAnyArgs().LikeUser(default, default);
+		await repository.DidNotReceiveWithAnyArgs().HasUserLiked(default, default);
+	}
+
+	[Fact]
+	public async Task Handle_LikedUserNotFound_Throws()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new LikeUserCommandHandler(repository);
+		var command = new LikeUserCommand(1, 2);
+
+		repository.GetById(command.LikedId)
+			.Returns(Task.FromResult<User?>(null));
+
+		await Assert.ThrowsAsync<UserNotFoundException>(() =>
+			handler.Handle(command, CancellationToken.None));
+
+		await repository.DidNotReceiveWithAnyArgs().LikeUser(default, default);
+		await repository.DidNotReceiveWithAnyArgs().HasUserLiked(default, default);
+	}
+
+	[Fact]
+	public async Task Handle_ReverseLikeDoesNotExist_ReturnsFalse()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new LikeUserCommandHandler(repository);
+		var command = new LikeUserCommand(1, 2);
+
+		repository.GetById(command.LikedId)
+			.Returns(Task.FromResult<User?>(CreateUser(command.LikedId)));
+		repository.HasUserLiked(command.LikedId, command.LikerId)
+			.Returns(Task.FromResult(false));
+
+		bool matched = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(matched);
+		await repository.Received(1).LikeUser(command.LikerId, command.LikedId);
+		await repository.Received(1).HasUserLiked(command.LikedId, command.LikerId);
+	}
+
+	[Fact]
+	public async Task Handle_ReverseLikeExists_ReturnsTrue()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new LikeUserCommandHandler(repository);
+		var command = new LikeUserCommand(1, 2);
+
+		repository.GetById(command.LikedId)
+			.Returns(Task.FromResult<User?>(CreateUser(command.LikedId)));
+		repository.HasUserLiked(command.LikedId, command.LikerId)
+			.Returns(Task.FromResult(true));
+
+		bool matched = await handler.Handle(command, CancellationToken.None);
+
+		Assert.True(matched);
+		await repository.Received(1).LikeUser(command.LikerId, command.LikedId);
+		await repository.Received(1).HasUserLiked(command.LikedId, command.LikerId);
+	}
+
+	private static User CreateUser(int id)
+	{
+		return new User
+		{
+			Id = id,
+			Username = $"user{id}",
+			Password = "password",
+			Email = $"user{id}@example.com",
+			FirstName = "Test",
+			LastName = "User"
+		};
+	}
+}

--- a/backend/Matcha.Tests/UnlikeUserCommandHandlerTests.cs
+++ b/backend/Matcha.Tests/UnlikeUserCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+using Application.Commands;
+using Domain.Entities;
+using Domain.Exceptions;
+using Domain.Repositories;
+using NSubstitute;
+
+namespace Matcha.Tests;
+
+public class UnlikeUserCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_SelfUnlike_Throws()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new UnlikeUserCommandHandler(repository);
+		var command = new UnlikeUserCommand(1, 1);
+
+		await Assert.ThrowsAsync<SelfLikeException>(() =>
+			handler.Handle(command, CancellationToken.None));
+
+		await repository.DidNotReceiveWithAnyArgs().UnlikeUser(default, default);
+	}
+
+	[Fact]
+	public async Task Handle_LikedUserNotFound_Throws()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new UnlikeUserCommandHandler(repository);
+		var command = new UnlikeUserCommand(1, 2);
+
+		repository.GetById(command.LikedId)
+			.Returns(Task.FromResult<User?>(null));
+
+		await Assert.ThrowsAsync<UserNotFoundException>(() =>
+			handler.Handle(command, CancellationToken.None));
+
+		await repository.DidNotReceiveWithAnyArgs().UnlikeUser(default, default);
+	}
+
+	[Fact]
+	public async Task Handle_ExistingLikedUser_CallsRepository()
+	{
+		var repository = Substitute.For<IUserRepository>();
+		var handler = new UnlikeUserCommandHandler(repository);
+		var command = new UnlikeUserCommand(1, 2);
+
+		repository.GetById(command.LikedId)
+			.Returns(Task.FromResult<User?>(CreateUser(command.LikedId)));
+
+		await handler.Handle(command, CancellationToken.None);
+
+		await repository.Received(1).UnlikeUser(command.LikerId, command.LikedId);
+	}
+
+	private static User CreateUser(int id)
+	{
+		return new User
+		{
+			Id = id,
+			Username = $"user{id}",
+			Password = "password",
+			Email = $"user{id}@example.com",
+			FirstName = "Test",
+			LastName = "User"
+		};
+	}
+}

--- a/backend/matcha-app/Controllers/UsersController.cs
+++ b/backend/matcha-app/Controllers/UsersController.cs
@@ -106,4 +106,33 @@ public class UsersController (IMediator mediator) : ControllerBase
         await mediator.Send(command, token);
         return NoContent();
     }
+
+    [Authorize(Policy = "CompleteProfile")]
+    [HttpPost("{likerId}/likes/{likedId}")]
+    public async Task<IActionResult> LikeUser(int likerId, int likedId, CancellationToken token)
+    {
+        string? userIdClaim = User.FindFirst("sub")?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(userIdClaim, out int authenticatedUserId) || authenticatedUserId != likerId)
+        {
+            return Forbid();
+        }
+
+        LikeUserCommand command = new LikeUserCommand(likerId, likedId);
+        bool matched = await mediator.Send(command, token);
+        return Ok(new { matched });
+    }
+    
+    [HttpDelete("{likerId}/likes/{likedId}")]
+    public async Task<IActionResult> UnlikeUser(int likerId, int likedId, CancellationToken token)
+    {
+        string? userIdClaim = User.FindFirst("sub")?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(userIdClaim, out int authenticatedUserId) || authenticatedUserId != likerId)
+        {
+            return Forbid();
+        }
+
+        UnlikeUserCommand command = new UnlikeUserCommand(likerId, likedId);
+        await mediator.Send(command, token);
+        return NoContent();
+    }
 }

--- a/backend/matcha-app/Exceptions/GlobalExceptionHandler.cs
+++ b/backend/matcha-app/Exceptions/GlobalExceptionHandler.cs
@@ -10,13 +10,14 @@ public class GlobalExceptionHandler(IProblemDetailsService problemDetailsService
     {
         var statusCode = exception switch
         {
+            InvalidRefreshTokenException => StatusCodes.Status401Unauthorized,
             UserNotFoundException => StatusCodes.Status404NotFound,
+            PictureNotFoundException => StatusCodes.Status404NotFound,
             InvalidPasswordException => StatusCodes.Status422UnprocessableEntity,
             SamePasswordException => StatusCodes.Status422UnprocessableEntity,
-            InvalidRefreshTokenException => StatusCodes.Status401Unauthorized,
             PictureLimitExceededException => StatusCodes.Status422UnprocessableEntity,
-            PictureNotFoundException => StatusCodes.Status404NotFound,
             InvalidPictureUploadException => StatusCodes.Status422UnprocessableEntity,
+            SelfLikeException => StatusCodes.Status422UnprocessableEntity,
             DomainException => StatusCodes.Status422UnprocessableEntity,
             _ => StatusCodes.Status500InternalServerError
         };


### PR DESCRIPTION
## Summary
- add like and unlike commands and controller endpoints
- add repository support for idempotent likes/unlikes and mutual-like detection
- add SelfLikeException mapping and command handler tests

## Notes
- Reapplied M-26 on top of current main after the original PR was merged into the feature branch instead of main.
- Kept the logout ClearRefreshToken method from main while resolving conflicts.

## Testing
- Not run per instruction